### PR TITLE
Add commit message guidelines

### DIFF
--- a/commit-message-guidelines.md
+++ b/commit-message-guidelines.md
@@ -1,0 +1,32 @@
+# Commit Message Guidelines
+
+[Atomic commits](https://www.aleksandrhovhannisyan.com/blog/atomic-git-commits/) are preferred.
+
+## Subject/Title
+
+* Separate the title/subject of the commit message from the body of the commit message with a blank line.
+* Try to keep the title/subject descriptive and concise.
+* Capitalize the title/subject line, use the imperative mood, and don't end the line with a period.
+
+## Body
+
+* Explain what the commit does.
+* Explain why the commit does what it does.
+* Add any additional details that could be useful.
+
+## Example
+
+Add commit message guidelines
+
+What:
+Adds guidelines for commit messages to be used by contributors in all of our projects.
+
+Why:
+This keeps things standardized and predictable and encourages people to include the very important context of why they're making their changes.
+
+Note:
+The example for the body of the commit message doesn't have to be followed exactly, the most important part is that the commit message is clear and informative, but I find the headings useful for saving brain power by essentially just giving me a form to fill out, and helping make sure I think about what context I need to convey so that others (including my future self) will understand what I'm doing.
+
+## References:
+
+* https://cbea.ms/git-commit


### PR DESCRIPTION
## What?
<!-- Explain what your pull request does -->
Adds guidelines for commit messages to be used by contributors in all of our projects.

## Why?
<!-- Explain why you're opening this pull request, what limitations does it address, etc..  If you're addressing an open issue you can often just link to the issue -->
This keeps things standardized and predictable and encourages people to include the very important context of why they're making their changes.

## Limitations
<!-- List anything that isn't addressed, e.g. corner cases, and why they weren't addressed -->
The guidelines are kept fairly general and no rules are set for character count on lines.  This is done to keep the barrier of entry low.

## Alternatives considered
<!-- If there are any alternative ways of implementing this that you thought of, but decided against, list them here along with why they were discarded -->
We could enforce one commit per pull request and squash any with multiple when merging (which we may still have to do for pull requests with poor commit messages) and just use the pull request message as the commit message, but this could lose useful information (or result in extremely long commit messages if the pull request had lots of detailed commits) and could make bisects/reverts more difficult. 

## Open questions
<!-- List any questions you have -->
Do we want to suggest/enforce maximum line lengths for subject/body lines?

## Additional details or related context
<!-- Give any other details that you think the reviewers should be aware of -->
N/A
