### PR TITLE
Add policy for policy/procedure/guideline proposals

### DIFF
--- a/policy-procedure-guideline-proposal-policy.md
+++ b/policy-procedure-guideline-proposal-policy.md
@@ -1,0 +1,21 @@
+# Policy/Procedure/Guidelines Proposal Policy
+
+## Submitting Proposals
+
+Proposals for changes/additions to our policies, procedures, or guidelines can be submitted as pull requests to this repository and will remain open for a *minimum* of one week so that they can have a chance to be discussed.  They will then require at least one approval from the Governance Team from someone other than the originator of the proposal in order to be adopted/merged.
+
+## Announcing Changes
+
+Once a proposal pull request has been approved and merged, an announcement about the changes will be made in Discord that includes a link to the merged pull request.  If multiple proposals are approved and merged at the same time, the combined changes can be announced together in a single Discord announcement.  Updates that don't functionally change anything (e.g. typo fixes, formatting, etc.) do not need to be announced.
+
+## Announcement Template
+
+```
+:scroll: **Policies/Procedures/Guidelines Update** :scroll:
+@everyone
+
+Our polices/procedures/guidelines have changed.
+
+What's new:
+* [PullRequestName](link)
+```

--- a/policy-procedure-guideline-proposal-policy.md
+++ b/policy-procedure-guideline-proposal-policy.md
@@ -4,7 +4,7 @@
 
 Proposals for changes/additions to our policies, procedures, or guidelines can be submitted as pull requests to this repository and will remain open for a *minimum* of one week so that they can have a chance to be discussed.  They will then require at least one approval from the Governance Team from someone other than the originator of the proposal in order to be adopted/merged.
 
-## Announcing Changes
+## Announcing Changes (currently suspended)
 
 Once a proposal pull request has been approved and merged, an announcement about the changes will be made in Discord that includes a link to the merged pull request.  If multiple proposals are approved and merged at the same time, the combined changes can be announced together in a single Discord announcement.  Updates that don't functionally change anything (e.g. typo fixes, formatting, etc.) do not need to be announced.
 


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Adds a policy for how to handle changes/additions to our policies/procedures/guidelines.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're addressing an open issue you can often just link to the issue -->
To ensure that changes to our policies/procedures/guidelines are handled in a consistent manner and that this process is well documented and transparent/public.

## Limitations
<!-- List anything that isn't addressed, e.g. corner cases, and why they weren't addressed -->
This is only a basic policy and will likely need to be expanded in the future, e.g. to better accommodate teams other than the Governance Team.

## Alternatives considered
<!-- If there are any alternative ways of implementing this that you thought of, but decided against, list them here along with why they were discarded -->
None.

## Open questions
<!-- List any questions you have -->
We probably don't need/want to announce policy changes while we're still setting everything up, e.g. we've still got lots of draft stuff and/or aren't ready to fully implement ourselves, so we probably should either wait to merge this PR until the contribution page on hubsfoundation.org is finished, or just not follow the announcement part until then. 

## Additional details or related context
<!-- Give any other details that you think the reviewers should be aware of -->
The proposal submission part was discussed and decided on at the [2025-03-20 Governance Team meeting](https://docs.google.com/document/d/1Cv_3Ar2FNsPRl-4viW0-Y0K6um7r8RrcSEzMiOnfOqI/edit?tab=t.0#heading=h.hzkvf6ccaapr).
Suspending the announcement part for now was decided on at the [2025-06-05 Governance Team meeting](https://docs.google.com/document/d/1Cv_3Ar2FNsPRl-4viW0-Y0K6um7r8RrcSEzMiOnfOqI/edit?tab=t.0#heading=h.7nzq3lwagri9)