### PR TITLE
Adds mod guidelines for new Hubs relevant rule

### DIFF
--- a/hubs-discord-moderator-guidelines.md
+++ b/hubs-discord-moderator-guidelines.md
@@ -14,16 +14,16 @@ _(All moderators are free to propose changes)_
 
     “I am a front end engineer looking for a job, I have 3 years experience with Hubs. Here is my LinkedIn account.”  Post has a stated relevance to Hubs relevant. It is appropriate for the job-board channel.
 
-    Link to tech updates to Reticulum new article.  
+    Link to article covering tech updates to Reticulum.  
     Post could be improved with a stated connection but nonetheless, the post has an obvious connection to Hubs that is apparent to experienced Hubs community members. It is best for random or the dev channels. 
 
-    - Examples of post that are not OK:
+    - Examples of posts that are not OK:<p>
     Post contains only a link about trends in AI-assisted 3D object creation.
     Post has no obvious nor stated connection (no context) to Hubs. Post can be removed. Optional DM to member.
 
     Link only to site for a cannot-be-safely-determined purpose. 
     No obvious connection to Hubs. No added context to Hubs. Post can be removed. Optional DM to member.<p>
-***NSFW stuff**
+* **NSFW stuff**
   - Check whether the user has made any legitimate posts
   - Ban the user, select other and type in NSFW for the reason, and select the correct time frame for deleting their posts (they usually only have NSFW posts so you can probably select the past 7 days as the timeline to make sure you get them all)
   - Post in the #mods channel that you’ve banned a NSFW user (include the user’s name).


### PR DESCRIPTION
## What?
Adds moderator guidelines for a Hubs-relevant rule for the Hubs Discord original or first posts.
Includes examples of what does and does not follow the rule. Also includes moderator guidelines on channels where enforcement should not be as strict.

## Why?
We occasionally see metaverse, crypto, other platform posts, or posts where any connection to Hubs seems missing. Making this a server rule for all members will help enforcement because especially new members will have just agreed to it upon joining. Therefore, members can be held to this rule. Moderators can, if they have to, remove posts or at least minimally ask the original poster to edit/add Hubs relevance to the post. Moderators should check out links, and/or investigate the posting member, and remove posts if they are not relevant to the Hubs community.

Note: If discussion approves adding this as a Discord rule, that will need to be done at Discord separately as:
12. Make posts relevant to Hubs

An alternative idea floated in discussion is that Hubs relevance be added to rule #3. "Use appropriate language. This is a professional environment."

There are two key changes included in this rule:

1. The post must be obviously Hubs related OR the posting member must make it relevant by adding context to their post (usually this will be added text) that makes the perceived connection between Hubs and the content clear.

2. It places some responsibility on the Moderators to keep the rest of the community safe by checking links, which might be spam, or by investigating the posting members by using publicly available data.

## Limitations
Encourages moderators to step in and take more action than they have been used to.
This rule is not meant to conflict with any prior Moderator guideline.  If anything, it should be a stronger policy reason to delete questionable content.


## Alternatives considered
Current Discord moderation guidelines are good and come close to addressing non-Hubs content. A Hubs-relevant rule would be required of all members and therefore would put some of the burden on the members following the rule, not just Moderators making decisions.


## Open questions
None at this time


## Additional details or related context
Per conversation, this change would need an announcement and a change to the Discord rules.

Discussion on the following text has already occurred because it was placed inside the commit-- see edits immediately following.  The text is now removed from the commit.


Moderators could delete posts, then directly message the member that the original poster is welcome to re-post if they add context about connection to Hubs. If the member refuses, the original post stays deleted. If a member posts repeatedly, is messaged about relevance, and does not re-post, the Moderators could take this as a reason to remove the member from the server. All this could be documented in the admin private channel.

[EDIT: There has been discussion on the fact that once a Discord post is deleted, it is gone; it cannot be retrieved by a moderator or admin.  There are times, however, when a to-be deleted post would be captured (cut-and-paste of text or screen captured) and the content of the post could be either re-presented to the member to re-post themselves OR the moderator could re-post with a text credit to the member.  So there are ways around the problem of something being deleted and then re-posted. 

Further, there has been discussion and agreement on "extreme cases" (very egregious posts which should be deleted) and "confusing cases" (where the moderator truly does not know what to do and leaving a post up might cause harm). These are likely to really rare. Writing rules for edges cases seems like a waste of time. Therefore, discussion these possible situations is ended.  All of the prior existing moderator guidelines do a good job of guiding moderators through most situations.]



The random (and off-topic?) channel should have a wide leeway for posts not related to Hubs. Still, all Discord server rules apply. Most of the posts we’ve seen that have been deleted are blatant server violations. When in doubt, it is safest to take a post out of public view while it is being discussed with other Mods.

[EDIT: discussion did not favor pre-full deicison deletion. Therefore this text represents discussion, not decision or counsel.]
