### PR TITLE
Update "Share of the Month" rules link in the "Voting Notification Message Template"

### DIFF
--- a/share-of-the-month.md
+++ b/share-of-the-month.md
@@ -50,7 +50,7 @@ _For Hubs Foundation (Volunteer) Staff_
 @everyone
 Hello community!  The above are the posts from the https://discord.com/channels/498741086295031808/1063489773072830609 channel that are up for winning the <month> Share of the Month.  Please vote for the post you would like to see win! :grin:
 
-Share of the Month rules: https://docs.google.com/document/d/1xdD_M4xnQsLJBRJsoE4pwSpyaInBwuThL5dJ8OUSWxs/edit?usp=sharing
+Share of the Month rules: https://github.com/Hubs-Foundation/policies-procedures-guidelines-public/blob/main/share-of-the-month.md
 ```
 
 ### Announcement Template:


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Changes the "Share of the Month" rules link in the "Voting Notification Message Template" from the old Google Docs document to the document in this repository.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're addressing an open issue you can often just link to the issue -->
This link got missed when the rules were moved to the policies-procedures-guidelines-public repository.

## Limitations
<!-- List anything that isn't addressed, e.g. corner cases, and why they weren't addressed -->
None.

## Alternatives considered
<!-- If there are any alternative ways of implementing this that you thought of, but decided against, list them here along with why they were discarded -->
None.

## Open questions
<!-- List any questions you have -->
None.

## Additional details or related context
<!-- Give any other details that you think the reviewers should be aware of -->
None.
