### PR TITLE
Add copyright policy

### DIFF
--- a/copyright-policy.md
+++ b/copyright-policy.md
@@ -1,0 +1,23 @@
+# Copyright Policy
+The <full name of not for profit coporation> (hereafter referred to as the "Hubs Foundation") does not seek to claim ownership or copyright for anything beyond what is absolutely necessary for the operation of the Hubs Foundation and will seek to provide an appropriately permissive license wherever possible/reasonable.
+
+For clarity, assets are any files, folders, or collections of files/folders.
+
+
+## Unlicensed Assets:
+Unless otherwise specified, creation of or modification to Hubs Foundation owned assets, that do not have a license, are licensed from the contributor to the Hubs Foundation with a non-exclusive, worldwide, royalty-free, irrevocable license that allows the Hubs Foundation to deal in the assets without restriction, including but not limited to using, copying, modifying, merging, publishing, distributing, sublicensing, and/or selling copies of the assets.  Any and all warranty and/or liability for the creation of or modification to the assets is disclaimed by the contributor to the fullest extent possible.
+
+
+## Licensed Assets:
+Unless otherwise specified, creation of or modification to licensed assets are licensed to the Hubs Foundation under the license the assets are released under and do not transfer any copyright to the Hubs Foundation.  All contributors allow the Hubs Foundation to act on their behalf to enforce this license.
+
+
+## Special Exceptions:
+
+1. Full transfer to the Hubs Foundation
+Creation of or modification to assets that are designated to fall into this special exception (such as, but not limited to, trademarks, logos, branding, etc.), regardless of whether the assets have a license for use or not, will transfer, or if that is not possible exclusively license, all the rights/ownership/copyright/etc. of the created asset/modification to the Hubs Foundation to the fullest extent possible, except for the following exception.
+
+In no event will the Hubs Foundation claim sole right/ownership/copyright/etc. of any techniques, processes, inventions, discoveries, solutions, ways of doing things, designs, ideas, algorithms, patents, trade secrets, knowledge, etc. that are developed or used for that created asset/modification.  However, the contributor agrees to give a non-exclusive, worldwide, royalty-free, irrevocable license to the Hubs Foundation for the aforementioned techniques, processes, etc. that were developed or used for the created asset/modification.
+
+2. Full license to the Hubs Foundation
+Creation of or modification to assets that are designated to fall into this special exception, regardless of whether the assets have a license for use or not, are licensed to the Hubs Foundation with a non-exclusive, worldwide, royalty-free, irrevocable license that allows the Hubs Foundation to deal in the assets without restriction, including but not limited to using, copying, modifying, merging, publishing, distributing, sublicensing, and/or selling copies of the assets.  Any and all warranty and/or liability for the creation of or modification to the assets is disclaimed by the contributor to the fullest extent possible.

--- a/copyright-policy.md
+++ b/copyright-policy.md
@@ -21,3 +21,7 @@ In no event will the Hubs Foundation claim sole right/ownership/copyright/etc. o
 
 2. Full license to the Hubs Foundation
 Creation of or modification to assets that are designated to fall into this special exception, regardless of whether the assets have a license for use or not, are licensed to the Hubs Foundation with a non-exclusive, worldwide, royalty-free, irrevocable license that allows the Hubs Foundation to deal in the assets without restriction, including but not limited to using, copying, modifying, merging, publishing, distributing, sublicensing, and/or selling copies of the assets.  Any and all warranty and/or liability for the creation of or modification to the assets is disclaimed by the contributor to the fullest extent possible.
+
+## License obligations by the Hubs Foundation that apply to unlicensed assets and assets that fall under Special Exception #2
+
+The Hubs Foundation agrees to only (sub)license these assets, their modifications, or anything based on or derived from them, under the terms of one or more of the licenses the Free Software Foundation classifies as Free Software Licenses.


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Provides rules for how licensing/copyright will be handled for contributions.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're addressing an open issue you can often just link to the issue -->
So that people will clearly know what will happen with their copyright and what licenses they are providing when contributing.  This also allows us to dual license stuff, or transfer the copyright from contributors (provided we also get their signature when transferring the copyright), in certain circumstances.

## Limitations
<!-- List anything that isn't addressed, e.g. corner cases, and why they weren't addressed -->
This only has provisions for either everyone working under a specified license or a full license/transfer of everything to the Hubs Foundation.  This seems to makes sense for the usecases I'm envisioning, but in the future we may also want an option for a more restricted license to the Hubs Foundation.

## Alternatives considered
<!-- If there are any alternative ways of implementing this that you thought of, but decided against, list them here along with why they were discarded --> 
Licensing everything under normal open source licenses, but this could cause issues with stuff in generic or working files that we might want to use in places with different licenses.
Making transferring the copyright the default for things like working/internal files, but I think this isn't necessary and would go against the spirit of open source.

## Open questions
<!-- List any questions you have -->
Are either of the licenses to the Hubs Foundation in `Unlicensed Assets` and `Special Exception #2` too broad?
Which files do we want to apply `Special Exception #1` to?
Which files do we want to apply `Special Exception #2` to?

## Additional details or related context
<!-- Give any other details that you think the reviewers should be aware of -->
* This hasn't been reviewed by a lawyer, but we almost certainly should before approving it.
* We will need to fill in the legal name of the Hubs Foundation before merging.
