### PR TITLE
Add guidelines for moderating the meetup channel Hubs room

### DIFF
--- a/hubs-discord-moderator-guidelines.md
+++ b/hubs-discord-moderator-guidelines.md
@@ -74,11 +74,11 @@ _(All moderators are free to propose changes)_
 
 ## Meetup channel Hubs room.
 
-If someone misbehaves in the meetup channel's Hubs room or sends inappropriate messages in the chat to the meetup channel, i.e. they violate our community rules, take the following action:
+If someone misbehaves in the meetup channel's Hubs room or sends inappropriate messages in the chat to the meetup channel via the Hubs Discord bot, i.e. they violate our community rules, take the following action:
 
-1. Join the meetup room (if needed).
-2. Find the problem user and kick them (you can kick them by opening the people menu, clicking on their name, and then selecting kick).
-3. Prevent the problem user from viewing the meetup channel via one of the following methods (depending on the severity of the offense):
+1. Join the meetup channel's Hubs room (if needed).
+2. Find the problem user and kick them from the Hubs room (you can kick them by opening the people menu, clicking on their name, and then selecting kick).
+3. Prevent the problem user from viewing the meetup channel on Discord via one of the following methods (depending on the severity of the offense):
     1. Assign them the "Meetup Room Timeout" discord role for X days (note: you will manually have to remove the role when the time is up).
     2. Kick them from the server.
     3. Ban them from the server.


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Adds a new section to the moderator guidelines with an itemized list of actions to take if someone misbehaves in the meetup room.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're addressing an open issue you can often just link to the issue -->
Moderating a Hubs room that is bridged to Discord is different from moderating the Discord channels, so it needs special instructions.

## Limitations
<!-- List anything that isn't addressed, e.g. corner cases, and why they weren't addressed -->
* Currently, only admins can change the role of a user.  Discord doesn't provide a permission that allows assigning roles and nothing else, so we'd either need to give moderators the manage roles permission or add a bot that allows moderators to assign roles (or something else I haven't thought of).
* This is fairly basic and may not cover every case, but it's a start.

## Alternatives considered
<!-- If there are any alternative ways of implementing this that you thought of, but decided against, list them here along with why they were discarded -->
None.

## Open questions
<!-- List any questions you have -->
How to allow moderators to assign roles.

## Additional details or related context
<!-- Give any other details that you think the reviewers should be aware of -->
This is needed now that the Hubs bot is bridging the chat to the meetup channel again.
