### PR TITLE
Add AI usage policy

### DIFF
--- a/ai-usge-policy.md
+++ b/ai-usge-policy.md
@@ -1,0 +1,30 @@
+# AI Usage Policy
+
+Generative AI can be a valuable tool to aid contributors, but it can also introduce legal risks and result in lower quality contributions if not used properly.  In order to ensure that AI usage is of net benefit to the project, the following rules and guidelines have been adopted.
+
+## Rules
+
+1. We require any submissions (issues, pull requests, commits, comments, etc.) that use AI tools to disclose this and what parts it was used for.  If the actual thing getting integrated used AI tools as part of its creation, then what AI program and model was used (e.g. ChatGPT using the GPT-5 model, Claude Code using the Sonnet 4.5 model, GitHub Copilot using the Gemini 2.5 Pro model, etc.) should be documented as well.  Reviewers/Triagers are encouraged to inquire about AI tool usage.  *Reasoning: this ensures that if there are any legal issues (or any other issues) they can be addressed, potentially by the removal of the AI generated content if needed.  Reviewers/Triagers can also do their jobs better if they know whether they're dealing with AI content.*
+
+2. We strongly encourage people to only use AI as assistive tools, e.g. asking questions to help in understanding something, polishing writing outside of contributions (such as pull request descriptions, comments on pull requests/issues, etc.), generating a first draft that is then rewritten completely (or the majority of it is), generating repetitive boilerplate that is then filled in by the contributor, etc..
+
+3. We require contributors that use AI tools in their submissions to understand and stand behind their submissions the same as if they had written them entirely on their own.
+
+4. We require contributors to always be confident that they are the principle owner, and control the copyright, of the AI assisted contribution they submit.
+
+5. We will reject any normally copyrightable submissions that appear to be significantly (or fully) AI generated, e.g. anything that has been "vibe-coded".  *Reasoning: unmodified or mostly unmodified AI output is often considered public domain and not owned by the contributor and so won't follow the terms of our license, and/or it may contain content that is incompatible with our license.*
+
+Note: If submissions don't comply with this policy, reviewers are encouraged to attempt to help submitters refactor their submission to comply with this policy.
+
+## Guidelines
+
+The recommended disclosure for AI tool usage is as follows:
+
+Level 1
+Usage of AI for personal edification, e.g. asking AI to explain how something works, doesn't need to be disclosed as this doesn't directly affect the project.  Note: if you are copy/pasting AI responses back to people, then the second level of disclosure should apply.
+
+Level 2
+Usage of AI for the generation of anything outside the actual thing getting integrated, e.g. using AI to open an issue or write a commit message, should be disclosed, along with what it was used for, so that people can handle it appropriately.  Disclosing which AI programs were used is encouraged, but not necessarily required.
+
+Level 3
+Usage of AI for the generation of the actual thing getting integrated, e.g. using AI to generate part of your code or other assets that you are submitting, should be disclosed along with as many details as you have, e.g. which AI programs were used, what models they used, what you used them for, etc..  Note: this should be included in both the pull request description and the actual commits where AI tools are used, however, you can likely stop at the commit level and just document what AI the commit used without needing to give a breakdown of each line within the commit that used AI, i.e. the whole commit would be considered to be AI assisted.


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Adds a new document containing rules for AI tool usage and guidelines on the disclosure of AI tool usage.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're addressing an open issue you can often just link to the issue -->
* To minimize legal risks to the project and help ensure AI assisted submissions are high quality, and can be handled smoothly and consistently.
* Pull requests that use AI tools have been increasing.

## Limitations
<!-- List anything that isn't addressed, e.g. corner cases, and why they weren't addressed -->
This doesn't address any form of detection of AI generated material, other than asking people, or the implementation of any scanning tools to look for AI generated or copyrighted material (as mentioned in point 4 of Imaginer's proposal in Discord).

## Alternatives considered
<!-- If there are any alternative ways of implementing this that you thought of, but decided against, list them here along with why they were discarded -->
* Not having an AI usage policy until things are more settled in court or until we get more pull requests that use AI.  However, it feels like by then it will be too late if there are any issues, and a lot of other projects are creating AI usage policies or have already created them, so it feels like a good idea to have one.
* Not rejecting fully AI generated submissions.  However, there seems to be a pretty clear consensus that these submissions are either public domain, which would erode our license, or at risk of being copyrighted or under some unknown license (which would open us up to legal risks); there is also the risk of them introducing security vulnerabilities.
* A reduction in disclosure requirements, e.g. only requiring the main program name and not the model, or just that AI was used with no more specifics.  However, if there are any issues with a program or model, we need to know this information in order to address them.

## Open questions
<!-- List any questions you have -->
Will this apply effectively across the board to all uses of AI as intended or does it need some modifications for non-code related AI usage?

## Additional details or related context
<!-- Give any other details that you think the reviewers should be aware of -->
This has been discussed heavily in Discord and at the various meetups and I expect there will be more discussion here and potentially changes to this policy.  **Everyone is welcome to weigh in on this! (As always)**

This is intended to apply to all AI usage, whether it's writing/documentation, media, code, etc..  However, there may need to be area specific modifications or separate area specific policies may need to be broken off.

This has been largely based off of the proposal at the end of Imaginer's initial AI concerns post in Discord and the disclosure guidelines suggested in a subsequent post by Imaginer, along with input from Doug Reeder at the Dev Meetups.

Reference Links:
Imaginer's AI concerns Discord post:
https://discord.com/channels/498741086295031808/535606666708910101/1429839515010207775

Imaginer's suggested disclosure guidelines:
https://discord.com/channels/498741086295031808/535606666708910101/1436666376344309791

Various AI policy discussions at the Dev Meetups:
https://docs.google.com/document/d/1OMh3-_DpjHABMMrXtECzLPNxipQMixx32l6K4zqSoYY/edit?tab=t.0

Links to AI/copyright related issues/policies/advice/etc.:
<details><summary>Expand to show links.</summary>
<ul>
<li><a href="https://www.zdnet.com/article/if-chatgpt-produces-ai-generated-code-for-your-app-who-does-it-really-belong-to/">https://www.zdnet.com/article/if-chatgpt-produces-ai-generated-code-for-your-app-who-does-it-really-belong-to/</a></li>
<li><a href="https://www.zdnet.com/article/if-your-ai-generated-code-becomes-faulty-who-faces-the-most-liability-exposure/">https://www.zdnet.com/article/if-your-ai-generated-code-becomes-faulty-who-faces-the-most-liability-exposure/</a></li>
<li><a href="https://law.stackexchange.com/questions/107474/what-happens-when-code-written-with-genai-is-open-sourced">https://law.stackexchange.com/questions/107474/what-happens-when-code-written-with-genai-is-open-sourced</a></li>
<li><a href="https://www.bloomberglaw.com/external/document/X4H9CFB4000000/copyrights-professional-perspective-ip-issues-with-ai-code-gener">https://www.bloomberglaw.com/external/document/X4H9CFB4000000/copyrights-professional-perspective-ip-issues-with-ai-code-gener</a></li>
<li><a href="https://www.linuxfoundation.org/legal/generative-ai">https://www.linuxfoundation.org/legal/generative-ai</a></li>
<li><a href="https://web.archive.org/web/20251020122138/https://github.com/features/copilot">https://web.archive.org/web/20251020122138/https://github.com/features/copilot</a> (The original source of the 1% number seems to be this page in the FAQ section under Responsible AI > What are the intellectual property considerations when using GitHub Copilot)</li>
<li><a href="https://dev.to/rachellovestowrite/copyleft-licenses-a-comprehensive-guide-for-open-source-and-commercial-success-31np">https://dev.to/rachellovestowrite/copyleft-licenses-a-comprehensive-guide-for-open-source-and-commercial-success-31np</a></li>
<li><a href="https://en.wikipedia.org/wiki/Copyleft">https://en.wikipedia.org/wiki/Copyleft</a></li>
<li><a href="https://www.gnu.org/licenses/gpl-faq.en.html#CombinePublicDomainWithGPL">https://www.gnu.org/licenses/gpl-faq.en.html#CombinePublicDomainWithGPL</a></li>
<li><a href="https://lwn.net/ml/all/xmqqcyalm0mh.fsf@gitster.g/">https://lwn.net/ml/all/xmqqcyalm0mh.fsf@gitster.g/</a></li>
<li><a href="https://github.com/qemu/qemu/commit/3d40db0efc22520fa6c399cf73960dced423b048">https://github.com/qemu/qemu/commit/3d40db0efc22520fa6c399cf73960dced423b048</a></li>
<li><a href="https://www.netbsd.org/developers/commit-guidelines.html">https://www.netbsd.org/developers/commit-guidelines.html</a></li>
<li><a href="https://wiki.gentoo.org/wiki/Project:Council/AI_policy">https://wiki.gentoo.org/wiki/Project:Council/AI_policy</a></li>
<li><a href="https://discourse.gnome.org/t/loupe-no-longer-allows-generative-ai-contributions/27327">https://discourse.gnome.org/t/loupe-no-longer-allows-generative-ai-contributions/27327</a></li>
<li><a href="https://pivot-to-ai.com/2025/07/22/open-source-projects-reject-ai-code-over-copyright-concerns/">https://pivot-to-ai.com/2025/07/22/open-source-projects-reject-ai-code-over-copyright-concerns/</a></li>
<li><a href="https://discourse.llvm.org/t/our-ai-policy-vs-code-of-conduct-and-vs-reality/88300">https://discourse.llvm.org/t/our-ai-policy-vs-code-of-conduct-and-vs-reality/88300</a></li>
<li><a href="https://shujisado.org/2025/07/02/how-can-open-source-projects-accept-ai-generated-code-lessons-from-qemus-ban-policy/">https://shujisado.org/2025/07/02/how-can-open-source-projects-accept-ai-generated-code-lessons-from-qemus-ban-policy/</a></li>
<li><a href="https://news.itsfoss.com/curl-ai-slop/">https://news.itsfoss.com/curl-ai-slop/</a></li>
<li><a href="https://socket.dev/blog/oss-maintainers-demand-ability-to-block-copilot-generated-issues-and-prs">https://socket.dev/blog/oss-maintainers-demand-ability-to-block-copilot-generated-issues-and-prs</a></li>
<li><a href="https://pivot-to-ai.com/2025/05/13/if-ai-is-so-good-at-coding-where-are-the-open-source-contributions/">https://pivot-to-ai.com/2025/05/13/if-ai-is-so-good-at-coding-where-are-the-open-source-contributions/</a></li>
<li><a href="https://dlab.berkeley.edu/news/navigating-ai-tools-open-source-contributions-guide-authentic-development">https://dlab.berkeley.edu/news/navigating-ai-tools-open-source-contributions-guide-authentic-development</a></li>
<li><a href="https://communityblog.fedoraproject.org/council-policy-proposal-policy-on-ai-assisted-contributions/">https://communityblog.fedoraproject.org/council-policy-proposal-policy-on-ai-assisted-contributions/</a></li>
<li><a href="https://www.redhat.com/en/blog/when-bots-commit-ai-generated-code-open-source-projects">https://www.redhat.com/en/blog/when-bots-commit-ai-generated-code-open-source-projects</a></li>
</ul>
</details>