### PR TITLE
Adds initial draft of demo server policies

### DIFF
--- a/demo-server-policies.md
+++ b/demo-server-policies.md
@@ -1,0 +1,46 @@
+# Policies for the demo server (https://demo.hubsfoundation.org/)
+
+## Demo worlds
+
+* Scenes should showcase the capabilities of Hubs
+* A room should be removed from the homepage (public: off) if and when a better scene is available
+* Permissions
+  * Shared link
+  * Public: on
+  * Voice chat: off
+  * Text chat: off
+  * Create and move objects: on
+  * Create cameras: on
+  * Pin objects: off
+  * Create drawings: off
+  * Create emoji: on
+  * Allow flying: on
+  * Enable bitECS Client: off
+
+
+Non-goal: recreate all the scenes from hubs.mozilla.com
+
+
+## Providing meeting space for other groups
+
+Meeting space for other groups will be provided only to move that group from "a couple of people are excited" through "hold a meeting using Hubs". After that, the group will need to arrange for their own Hubs meeting space, either
+* donated by a person or group other than the Hubs Foundation,
+* paid for by the group, or
+* an instance maintained by the other group
+
+### Requirements/Restrictions on them
+
+* Aligned with our mission and policy, as decided by Governance council
+* Limited term, perhaps two weeks
+* They must not use Hubs Foundation name or logo to imply endorsement
+* Acknowledge that they are responsible for enforcing a code of conduct not significantly looser than ours, but we reserve the right to take any action necessary
+* Plan for 24 active participants per room and up to 75 spectators, with no reserved seating
+* They must provide their own forum to disseminate the URL and instructions
+* They must provide their own "ushers" to onboard users, help them learn controls, and who know how to mute and kick users.
+* If any support from the Hubs Foundation is required (for example, selecting a scene or configuring permissions, or to ensure the server stays up), the other group must pay the support staff.
+
+### Tasks/Requirements on us
+
+* Record Keeping
+  * Who has gotten a free trial
+* All legal policies posted


### PR DESCRIPTION
## What?
Adds initial draft of demo server policies

## Why?
1. to guide the selection and permissions of public rooms on the demo server
2. to set forth the responsibilities of any group we allow to hold a meeting on the demo server

## Limitations
We won't provide meeting space for other groups at all, until we have all our legal policies in place
