### PR TITLE
Adds initial version of Privacy Policy

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,0 +1,101 @@
+# Hubs Privacy Policy
+
+## Definitions
+
+**Site Owner**: The person, people or group operating an instance of Hubs
+
+**Administrator**: [Does this need to be defined separately???] 
+
+**Hubs Foundation**: 16009034 CANADA FOUNDATION, a Canadian Not-for-profit corporation
+
+## Entities and Jurisdictions
+
+Instances of Hubs are operated by various organizations and individuals, who choose their own administrators and choose their own hosting arrangements, including the jurisdiction.
+This means that your information might be processed on servers located outside of the country where you live, and that country may have a different level of data protection regulation than yours.
+Other users may be located outside of the country where you live, so information they have access to may have a different level of data protection regulation than yours.
+
+The Site Operator for an instance is responsible for compliance with all applicable privacy laws. 
+
+The Hubs Foundation is only responsible for the servers and Hubs instances it operates, and has no authority nor control over other servers and instances.
+
+## Information Shared With Hubs and Other Participants
+
+**Account information**: No account is needed for basic use of Hubs. 
+Certain features (like storing your avatar), do require an account. 
+Rooms that are linked to Discord require a Discord account. 
+You can create an account through Hubs or through Discord.
+If you create an account with your email address, the Site Owner stores a hashed version of your email address, and may recover your account from email logs.
+If you create an account through Discord, Hubs receive the email address associated with your Discord account and your Discord avatar.
+
+**Room names and URLs**: Rooms and room names are publicly accessible to anyone with the URL.
+The instance stores the name and the URL for the link you share so you and others with the link to the Room can use it again.
+
+**Avatar data**: Your selected avatar and name will be shared with other participants in your rooms and the host of your Hubs instance.
+If you’re logged in to your account, Hubs will store your avatar.
+If you’re not logged into your account, Hubs will not store your avatar.
+
+**Voice data**: If your microphone is on, Hubs sends the audio to other users in the room, including users in the lobby.
+Hubs does not store the audio; Hubs only receive it temporarily to transmit it to others in the room.
+
+**Chat**: If you send messages in Hubs, Hubs shares it with the other users in the room, including users in the lobby.
+Hubs does not store chats; Hubs only receives it temporarily to transmit it to others in the room.
+
+**Photos and Videos You Take, and Photos, Videos, and Objects You Upload**: If you take photos and video in a Hubs room or upload photos, videos, or objects to a room, Hubs stores them so you can share them within the room.
+They are deleted within 72 hours unless you pin them.
+If you pin them they will be stored until you remove them from the room, and they will be viewable by anyone who can access the room.
+
+You can learn more by looking at the code itself: [Hubs](https://github.com/Hubs-Foundation/hubs) (the front-end) [Dialog](https://github.com/Hubs-Foundation/dialog) (the webRTC server), [Reticulum](https://github.com/Hubs-Foundation/reticulum) (the backend web server), [Hubs-Ops](https://github.com/Hubs-Foundation/hubs-ops) (the infrastructure code), [Discord Bot](https://github.com/Hubs-Foundation/hubs-discord-bot) (enables users to connect their Discord community to Hubs).
+
+## Other Information Hubs Receives
+
+Hubs use technical, interaction, error, and website analytics data to help us improve the Hubs experiences:
+
+**Technical data**: Hubs receives data about the type of devices used to interact with Hubs, as well as their operating systems, languages, the names and versions of browsers, and other data needed to load and operate a room.
+
+**Interaction data**: Hubs received data about interactions with Hubs, such as the number of rooms created, messages sent through or to third-party services like Discord (including aggregated counts such as the number of messages and users who have joined relevant channels), the number of users in a particular room, the start and end time of users’ interactions with Hubs, the amount of time users interact with Hubs in immersive sessions, and the first time in a particular month or day that a user begins to use Hubs.
+
+**Error Data**: When the Hubs client crashes or fails, Hubs receives error messages which may include the room URL, response time for requests, the page a user was on when the error happened, the user’s operating system, browser information, and IP address.
+
+**Website Analytics Data**: The Site Owner may use Google Analytics (GA) to better understand how people interact with Hubs.
+For example, Hubs collect de-identified information about the number of Hubs rooms created or entered, interactions with buttons and menus, session length, user location (country, state/province, and city), language settings, browser type and version, viewport size, and screen resolution.
+~~You can opt-out of GA data collection by installing the Google Analytics Opt-out Browser Add-on.~~
+
+## Information Hubs Collect for Published Scenes and Custom Avatars
+
+**Scenes and avatars you create**: Hubs stores scenes and avatars that users create so Hubs can display them.
+
+**Attribution information**: When someone publishes a scene or avatar to Hubs, they have the option to “Allow Remixing with Creative Commons CC-BY 3.0” or allow promotion of your scene or avatar. If the user chooses one or both of these options, Hubs will share the scene or avatar and attribution information publicly.
+
+**Account information**: To publish a scene or avatar to Hubs, a user must have a Hubs account.
+Hubs will receive and store a hashed version of their email address to allow them to log in and view their 3D Room models and Avatars.
+
+## Who Hubs May Disclose Information To
+
+**The Hubs Host**: When you use a Hubs instance, Hubs shares information with the Hubs subscriber who created the Hubs instance. This includes your username, information about your account and when you created it, as well as scenes, avatars, and other content you add to a Hubs room.
+
+**The hosting service**: If the Hubs instance is run using a hosting service, the service will collect some data.
+Ask the site operator for details.
+
+**Search providers**: You can search for images, videos, and 3D Models to share in Hubs.
+When you search, Hubs will send your searches to supported third parties to fulfill the search.
+Hubs does not store your search queries nor the search results.
+Hubs supports the following providers, not all of which may be available on an instance:
+* Sketchfab (models)
+* Icosa Gallery (models)
+* Bing Images (images)
+* Bing Videos (videos)
+* Tenor GIFs (GIFs)
+
+**Sharing**: Hubs allows you to share rooms, scenes, camera images, and camera videos using the system Sharing of your operating system.
+Any content you share will be handled according to the privacy policy of the service(s) you use.
+
+**Discord**: If a room you are in is connected to Discord, Hubs store access tokens and the server and channel IDs that have been connected.
+Hubs will synchronize chat messages, room changes, 2D and 3D objects you create, and whether you join or leave with the connected Discord channel.
+Hubs does not log any synchronized messages.
+You can see Discord’s Privacy Policy for more information.
+
+## Other Information You Should Know
+
+If you have any other questions regarding personal data or privacy practices, please contact the Site Owner.
+
+Please visit [the forums](https://discord.com/channels/1302953641115783198/1314206482438553631) for general support help. 


### PR DESCRIPTION
## What?
Adds initial version of Privacy Policy


## Why?
To inform users what information is collected and who has access to it.


## Limitations
Doesn't cover Terms of Service, which vary by instance.


## Open questions
Is this a Privacy Notice, rather than a Privacy Policy?


## Additional details or related context
Initially based off of Mozilla Hubs Privacy Notice (https://www.mozilla.org/en-US/privacy/archive/mozilla-hubs/notice-2024-06/) and Terms of Service (https://www.mozilla.org/en-US/privacy/archive/mozilla-hubs/tos-2024-06/)

